### PR TITLE
Add missing \

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ If you want sleep data, set the `OwenVoke\GoogleFitTile\Commands\FetchGoogleFitS
 
 protected function schedule(Schedule $schedule)
 {
-    $schedule->command(OwenVoke\GoogleFitTile\Commands\RefreshGoogleFitTokenCommand::class)->everyThirtyMinutes();
+    $schedule->command(\OwenVoke\GoogleFitTile\Commands\RefreshGoogleFitTokenCommand::class)->everyThirtyMinutes();
 
     // Data fetching commands
-    $schedule->command(OwenVoke\GoogleFitTile\Commands\FetchGoogleFitStepCountCommand::class)->everyTenMinutes();
-    $schedule->command(OwenVoke\GoogleFitTile\Commands\FetchGoogleFitSleepCommand::class)->everyTenMinutes();
+    $schedule->command(\OwenVoke\GoogleFitTile\Commands\FetchGoogleFitStepCountCommand::class)->everyTenMinutes();
+    $schedule->command(\OwenVoke\GoogleFitTile\Commands\FetchGoogleFitSleepCommand::class)->everyTenMinutes();
 }
 ```
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Without the \ it tries to search for the class in the app/ directory (e.g. ```App\Console\OwenVoke\GoogleFitTile\Commands\RefreshGoogleFitTokenCommand```)

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
